### PR TITLE
Clarify MTP definition

### DIFF
--- a/uahf-technical-spec.md
+++ b/uahf-technical-spec.md
@@ -15,9 +15,8 @@ fork - the sense of the requirements would largely stay the same.
 
 ## Definitions
 
-MTP: the "median time past" value of a block, calculated from the
-nTime values of its past up to 11 ancestors, as obtained by the
-GetMedianTimePast(block.parent) call.
+MTP: the "median time past" value of a block, calculated from its nTime
+value, and the nTime values of its up to 10 immediate ancestors.
 
 "activation time": once the MTP of the chain tip is equal to or greater
 than this time, the next block must be a valid fork block. The fork block


### PR DESCRIPTION
Make this consistent with the rest of the document.  Don't confuse the definition of MTP with the fact that elsewhere in the spec we refer to the MTP of a block's parent.